### PR TITLE
fix: update CONTRIBUTING.md link to absolute GitHub URL in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 > [!IMPORTANT]
 >
-> - Read [CONTRIBUTING.md](../CONTRIBUTING.md)  
+> - Read [CONTRIBUTING.md](https://github.com/ifLabX/agentifui-pro/blob/main/CONTRIBUTING.md)  
 > - Ensure issue exists and you're assigned  
 > - Link correctly: `Fixes #<issue number>`  
 > - All PRs must be created **in English**  


### PR DESCRIPTION
## Summary

Update the CONTRIBUTING.md link in the pull request template from a relative path to an absolute GitHub URL to ensure the link works correctly in all contexts.

The relative path `../CONTRIBUTING.md` has been replaced with `https://github.com/ifLabX/agentifui-pro/blob/main/CONTRIBUTING.md` to improve accessibility and reliability of the documentation reference.

## Type

- [x] 🐛 Bug fix  
- [ ] ✨ Feature  
- [ ] 💥 Breaking change  
- [ ] 📚 Docs  
- [ ] ♻️ Refactor  
- [ ] ⚡ Performance  

## Screenshots (if UI changes)

N/A - This is a documentation link update with no UI changes.